### PR TITLE
mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 **:warning: requirements**: fish `≥3.x`, [fisher](https://github.com/jorgebucaran/fisher):
 
 ```shell
-fisher install pure-fish/pure
+fisher install aayushgakhar/pure
 ```
 
 ## Features

--- a/functions/_pure_prompt_git.fish
+++ b/functions/_pure_prompt_git.fish
@@ -14,8 +14,48 @@ function _pure_prompt_git \
     set --local is_git_repository (command git rev-parse --is-inside-work-tree 2>/dev/null)
 
     if test -n "$is_git_repository"
-        set --local git_prompt (_pure_prompt_git_branch)(_pure_prompt_git_dirty)(_pure_prompt_git_stash)
-        set --local git_pending_commits (_pure_prompt_git_pending_commits)
+        git rev-parse --git-dir --is-inside-git-dir | read -fL gdir in_gdir
+        test $in_gdir = true && set -l _set_dir_opt -C $gdir/..
+        # Suppress errors in case we are in a bare repo or there is no upstream
+        set -l stat (git $_set_dir_opt --no-optional-locks status --porcelain 2>/dev/null)
+        string match -qr '(0|(?<stash>.*))\n(0|(?<conflicted>.*))\n(0|(?<staged>.*))
+    (0|(?<dirty>.*))\n(0|(?<untracked>.*))(\n(0|(?<behind>.*))\t(0|(?<ahead>.*)))?' \
+            "$(git $_set_dir_opt stash list 2>/dev/null | count
+            string match -r ^UU $stat | count
+            string match -r ^[ADMR] $stat | count
+            string match -r ^.[ADMR] $stat | count
+            string match -r '^\?\?' $stat | count
+            git rev-list --count --left-right @{upstream}...HEAD 2>/dev/null)"
+        if test -d $gdir/rebase-merge
+            # Turn ANY into ALL, via double negation
+            if not path is -v $gdir/rebase-merge/{msgnum,end}
+                read -f step <$gdir/rebase-merge/msgnum
+                read -f total_steps <$gdir/rebase-merge/end
+            end
+            test -f $gdir/rebase-merge/interactive && set -f operation rebase-i || set -f operation rebase-m
+        else if test -d $gdir/rebase-apply
+            if not path is -v $gdir/rebase-apply/{next,last}
+                read -f step <$gdir/rebase-apply/next
+                read -f total_steps <$gdir/rebase-apply/last
+            end
+            if test -f $gdir/rebase-apply/rebasing
+                set -f operation rebase
+            else if test -f $gdir/rebase-apply/applying
+                set -f operation am
+            else
+                set -f operation am/rebase
+            end
+        else if test -f $gdir/MERGE_HEAD
+            set -f operation merge
+        else if test -f $gdir/CHERRY_PICK_HEAD
+            set -f operation cherry-pick
+        else if test -f $gdir/REVERT_HEAD
+            set -f operation revert
+        else if test -f $gdir/BISECT_LOG
+            set -f operation bisect
+        end
+        set --local git_prompt (_pure_prompt_git_branch)' '$operation' '$step/$total_steps(_pure_prompt_git_stash $stash)' ~'$conflicted' +'$staged' '(_pure_prompt_git_dirty $dirty)' ?'$untracked
+        set --local git_pending_commits (_pure_prompt_git_pending_commits $ahead $behind)
 
         if test (_pure_string_width $git_pending_commits) -ne 0
             set --append git_prompt $git_pending_commits

--- a/functions/_pure_prompt_git_dirty.fish
+++ b/functions/_pure_prompt_git_dirty.fish
@@ -1,4 +1,5 @@
 function _pure_prompt_git_dirty
+    --argument-names dirty
     set --local git_dirty_symbol
     set --local git_dirty_color
 
@@ -19,7 +20,7 @@ function _pure_prompt_git_dirty
         and echo "true"
     )
     if test -n "$is_git_dirty"  # untracked or un-commited files
-        set git_dirty_symbol "$pure_symbol_git_dirty"
+        set git_dirty_symbol "$pure_symbol_git_dirty"$dirty
         set git_dirty_color (_pure_set_color $pure_color_git_dirty)
     end
 

--- a/functions/_pure_prompt_git_stash.fish
+++ b/functions/_pure_prompt_git_stash.fish
@@ -1,4 +1,5 @@
 function _pure_prompt_git_stash
+    --argument-names stash
     set --local git_stash_symbol
     set --local git_stash_color
 
@@ -7,7 +8,7 @@ function _pure_prompt_git_stash
         and echo "true"
     )
     if test -n "$has_stashed_files" # untracked or un-commited files
-        set git_stash_symbol " $pure_symbol_git_stash"
+        set git_stash_symbol " $pure_symbol_git_stash"$stash
         set git_stash_color (_pure_set_color $pure_color_git_stash)
     end
 


### PR DESCRIPTION
**related:** fixes #xxx

## How to test pre-release?

> :skull_and_crossbones: Feature **can** be unstable and break your prompt!

```shell
fisher install pure-fish/pure@feat/foo_feature # branch name
set --universal pure_enable_foo_feature true
```

## First contribution?

Check the [:+1: contributing guide][contributing] for code and naming conventions.

## Specs

### New config in `conf.d/pure.fish`

```fish
_pure_set_default pure_enable_foo_feature true
_pure_set_default pure_symbol_foo_feature "🤯"
```
<!-- remove if necessary -->

### Documentation

#### Usage

```shell
❯ set --universal pure_enable_feature_foo true
```

## Acceptance Checks

* [ ] Documentation is up-to-date:
  * [ ] Add entry in _feature list_ of [README.md][README] ;
  * [ ] Add entry in _features' overview_ in [docs/][features-overview]  ;
  * [ ] Add section in [feature list][features-list] to document
    * [ ] Features' flag ;
    * [ ] Prompt symbol ;
* [ ] Default are defined in [`conf.d/pure.fish`][default] for:
  * [ ] Feature flag ;
  * [ ] Symbol ;
* [ ] Tests are passing (I can help you :hugs: ):
  * [ ] Config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [ ] Feature is tested in `tests/feature_name.test.fish` ;
* [ ] Customization is available ;
* [ ] Feature is implemented.

[default]: /pure-fish/pure/blob/master/conf.d/pure.fish
[config-test]: /pure-fish/pure/blob/master/tests/_pure.test.fish
[contributing]: /pure-fish/pure/blob/master/CONTRIBUTING.md
[features-overview]: /pure-fish/pure/blob/master/docs/components/features-overview.md
[README]: /pure-fish/pure/blob/master/README.md
[features-list]: /pure-fish/pure/blob/master/docs/components/features-list.md
